### PR TITLE
build(fpm.toml): update version to 1.1.0

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "julienne"
-version = "0.1.0"
+version = "1.1.0"
 license = "license"
 author = "Damian Rouson, Brad Richardson, Patrick Raynaud, Katherine Rasmussen"
 maintainer = "damian@sourceryinstitute.org"


### PR DESCRIPTION
We might consider adopting the following versioning scheme in the [`fpm.toml`] file:

1. Use an even minor version number for releases, e.g., 1.0.0.
2. Use an odd minor version number between releases, e.g., 1.1.0.

This PR updates the version number accordingly from 1.0.0 to 1.1.0.

[`fpm.toml`]: https://github.com/sourceryinstitute/julienne/blob/main/fpm.toml